### PR TITLE
Fix case sensitive On Order check

### DIFF
--- a/Store_Stock_Dashboard_v1.0.0-beta.2.html
+++ b/Store_Stock_Dashboard_v1.0.0-beta.2.html
@@ -85,7 +85,7 @@
 
                         let inStock = row["Stock Status"] === "Red" ? "No" : "Yes";
 
-                        let onOrderGraphic = row["On Order"] === "True"
+                        let onOrderGraphic = (row["On Order"] || "").toString().toLowerCase() === "true"
                             ? '<img src="https://cdn-icons-png.flaticon.com/512/107/107831.png" class="on-order-icon" alt="On order">'
                             : "";
 

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
                             <td>${row["Stock Level"] || ""}</td>
                             <td>${row["Weeks of Stock (supplied)"] || ""}</td>
                             <td>${row["Stock Status"] || ""}</td>
-                            <td>${row["On Order"] === "True" ? "<span class='on-order'>Yes</span>" : "No"}</td>
+                            <td>${(row["On Order"] || "").toString().toLowerCase() === "true" ? "<span class='on-order'>Yes</span>" : "No"}</td>
                             <td>${row["binLocation"] || ""}</td>
                         `;
                         tbody.appendChild(tr);


### PR DESCRIPTION
## Summary
- fix `On Order` logic in dashboard HTML pages

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ccf1eacd4832da843e6fd6bef3407