### PR TITLE
Fix last update date retrieval

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,11 +114,15 @@
 
         function fetchLastUpdatedDate() {
             fetch("https://api.github.com/repos/martybo/Warehouse_Dashboard/commits?path=StockDashboardData.csv&per_page=1")
-                .then(res => res.csv())
+                .then(res => res.json())
                 .then(data => {
-                    const date = new Date(data[0].commit.committer.date);
-                    document.getElementById("updatedDate").textContent =
-                        "Last updated: " + date.toLocaleDateString("en-GB");
+                    if (Array.isArray(data) && data.length > 0) {
+                        const date = new Date(data[0].commit.committer.date);
+                        document.getElementById("updatedDate").textContent =
+                            "Last updated: " + date.toLocaleDateString("en-GB");
+                    } else {
+                        throw new Error("No commit data returned");
+                    }
                 })
                 .catch(() => {
                     document.getElementById("updatedDate").textContent = "Last updated: unknown";


### PR DESCRIPTION
## Summary
- Correct GitHub API response handling for last update date
- Guard against missing commit data when populating the dashboard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fc3030a00832db6526b3f134252b3