### PR TITLE
Fix data URL to restore search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here, using [Semantic Version
 
 ---
 
+## [1.1.1] - 2025-08-05
+### Fixed
+- Corrected broken data source path that prevented stock data from loading and search results from appearing.
+
 ### v1.0.0 (Public Release)
 - First production release
 - Includes:

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
     </footer>
 
     <script>
-        const DATA_URL = "StockDashboardDataconst DATA_URL = "https://raw.githubusercontent.com/martybo/Warehouse_Dashboard/main/StockDashboardData.json";.json";
+        const DATA_URL = "StockDashboardData.json";
 
         function loadJSON() {
             fetch(DATA_URL)


### PR DESCRIPTION
## Summary
- point DATA_URL at local StockDashboardData.json so rows populate and search works again
- document fix in changelog

## Testing
- `python -m json.tool StockDashboardData.json`

------
https://chatgpt.com/codex/tasks/task_e_6892012c32ec832dbe1901b8701f158a